### PR TITLE
Fix subscriptions with fragments

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/util/hasSubscription.ts
+++ b/packages/graphql-playground-react/src/components/Playground/util/hasSubscription.ts
@@ -17,9 +17,6 @@ function getSelectedOperation(
   }
 
   return operation.query.definitions.find(
-    d =>
-      d.kind === 'OperationDefinition' &&
-      !!d.name &&
-      d.name.value === operation.operationName,
+    d => d.kind === 'OperationDefinition'
   ) as OperationDefinitionNode
 }


### PR DESCRIPTION
Fixes https://github.com/prismagraphql/prisma/issues/2026.

Currently, if you execute a subscription with a fragment - it's executed in a POST request to the server. This pr fixes that behavior

![](https://i.imgur.com/fNKq23i.png)