### PR TITLE
fix(deps): Update express mw to latest graphql-playground-html

### DIFF
--- a/packages/graphql-playground-middleware-express/package.json
+++ b/packages/graphql-playground-middleware-express/package.json
@@ -34,7 +34,7 @@
     "typescript": "2.6.2"
   },
   "dependencies": {
-    "graphql-playground-html": "1.6.12"
+    "graphql-playground-html": "1.6.13"
   },
   "typings": "dist/index.d.ts",
   "typescript": {


### PR DESCRIPTION
graphql-playground-middleware-express package.json should now point to the latest version of html.

My team's licensing automation is still failing because the 1.6.13 fixes aren't being picked up by this pinned version
