### PR TITLE
Remove duplicate default display

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/DocExplorer/TypeLink.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/DocExplorer/TypeLink.tsx
@@ -163,14 +163,6 @@ class TypeLink extends React.Component<
           </span>
         )}
         <span className="type-name">{renderType(type.type || type)}</span>
-        {type.defaultValue !== undefined ? (
-          <DefaultValue>
-            {' '}
-            = <span>{`${JSON.stringify(type.defaultValue, null, 2)}`}</span>
-          </DefaultValue>
-        ) : (
-          undefined
-        )}
         {clickable && (
           <IconBox>
             <Triangle />
@@ -282,11 +274,4 @@ const IconBox = styled.div`
   right: 10px;
   top: 50%;
   transform: translateY(-50%);
-`
-
-const DefaultValue = styled.span`
-  color: ${p => p.theme.colours.black30};
-  span {
-    color: #1f61a9;
-  }
 `


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:

- Remove duplicate default definition

See example using schema from https://engine-graphql.apollographql.com/api/graphql

See schema for mutation `service->checkPartialSchema`. Frontend argument is no longer duplicating the default value