### PR TITLE
Removed unnecessary } in GraphQLEditor

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
@@ -288,7 +288,6 @@ class GraphQLEditor extends React.PureComponent<Props & ReduxProps> {
             />
           </SideTab>
         </SideTabs>
-        }
       </Container>
     )
   }


### PR DESCRIPTION
Fixes # N/A.

Changes proposed in this pull request:

It took a while to track down but there is a closing curly bracket that's unnecessary. It gets rendered in output and it's visible on white background. I removed it. This was introduced in #1001 https://github.com/prisma-labs/graphql-playground/pull/1001/files#diff-977e6e5ed829c1b17ed396af79ae26b3R291

## Before

This is a screenshot from master

<img width="928" alt="Screen Shot 2019-11-20 at 5 32 51 PM" src="https://user-images.githubusercontent.com/74687/69284195-0393da80-0bbc-11ea-9786-5c2ac720ab52.png">


## After

This is a screenshot from the Netlify preview app

<img width="992" alt="Screen Shot 2019-11-20 at 5 27 46 PM" src="https://user-images.githubusercontent.com/74687/69283842-2f629080-0bbb-11ea-80f7-a4189dee31fc.png">

