### PR TITLE
feat: run query on variable, header editor through ctrl+enter

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/GraphQLEditor.tsx
@@ -414,11 +414,9 @@ class GraphQLEditor extends React.PureComponent<Props & ReduxProps> {
     }
 
     const editor = this.queryEditorComponent.getCodeMirror()
-    if (editor.hasFocus()) {
-      const cursor = editor.getCursor()
-      const cursorIndex = editor.indexFromPos(cursor)
-      this.props.runQueryAtPosition(cursorIndex)
-    }
+    const cursor = editor.getCursor()
+    const cursorIndex = editor.indexFromPos(cursor)
+    this.props.runQueryAtPosition(cursorIndex)
   }
 
   private handleHintInformationRender = elem => {


### PR DESCRIPTION
Fixes #1140 

Changes proposed in this pull request:

- `runQueryAtCursor` shouldn't check if the query editor is on focus, as it will never be when used by Variable and Header editor
