### PR TITLE
fix: allow results to fill the entire pane horizontally

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/ResultViewer.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/ResultViewer.tsx
@@ -136,7 +136,6 @@ const Result = styled<ResultProps, 'div'>('div')`
   }
   .CodeMirror-scroll {
     overflow: auto !important;
-    max-width: 50vw;
     margin-right: 10px;
   }
   .CodeMirror-sizer {


### PR DESCRIPTION
Currently, the results pane is limited to a maximum width of `50vw`. When the pane is resized (to view long stack trace lines for example), the pane contents don't expand to fill the new space.

This PR fixes that by allowing the results pane to expand to fill the available horizontal space.

Changes proposed in this pull request:

- Remove the `max-width` CSS rule for `.CodeMirror-scroll`.

## Screenshots

|Before|After|
|-|-|
|<img width="1303" alt="Screen Shot showing long lines being wrapped even though there's ample space on the right side to display them unwrapped." src="https://user-images.githubusercontent.com/5957867/77918505-fd002880-7269-11ea-8b9b-c1a356008c4e.png">|<img width="1303" alt="Screen Shot showing long lines wrapped to fill the available horizontal space." src="https://user-images.githubusercontent.com/5957867/77918526-038ea000-726a-11ea-9169-1fbf96c6a185.png">

