### PR TITLE
chore: introduce dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,82 @@
+version: 1
+update_configs:
+  - package_manager: 'javascript'
+    directory: '/'
+    update_schedule: 'live'
+    allowed_updates:
+      - match:
+          update_type: 'security'
+    commit_message:
+      prefix: 'fix'
+      prefix_development: 'chore'
+      include_scope: true
+  - package_manager: 'javascript'
+    directory: '/packages/graphql-playground-react'
+    update_schedule: 'live'
+    allowed_updates:
+      - match:
+          update_type: 'security'
+    commit_message:
+      prefix: 'fix'
+      prefix_development: 'chore'
+      include_scope: true
+  - package_manager: 'javascript'
+    directory: '/packages/graphql-playground-html'
+    update_schedule: 'live'
+    allowed_updates:
+      - match:
+          update_type: 'security'
+    commit_message:
+      prefix: 'fix'
+      prefix_development: 'chore'
+      include_scope: true
+  - package_manager: 'javascript'
+    directory: '/packages/graphql-playground-electron'
+    update_schedule: 'live'
+    allowed_updates:
+      - match:
+          update_type: 'security'
+    commit_message:
+      prefix: 'fix'
+      prefix_development: 'fix'
+      include_scope: true
+  - package_manager: 'javascript'
+    directory: '/packages/graphql-playground-middleware-hapi'
+    update_schedule: 'live'
+    allowed_updates:
+      - match:
+          update_type: 'security'
+    commit_message:
+      prefix: 'fix'
+      prefix_development: 'fix'
+      include_scope: true
+  - package_manager: 'javascript'
+    directory: '/packages/graphql-playground-middleware-express'
+    update_schedule: 'live'
+    allowed_updates:
+      - match:
+          update_type: 'security'
+    commit_message:
+      prefix: 'fix'
+      prefix_development: 'fix'
+      include_scope: true
+  - package_manager: 'javascript'
+    directory: '/packages/graphql-playground-middleware-koa'
+    update_schedule: 'live'
+    allowed_updates:
+      - match:
+          update_type: 'security'
+    commit_message:
+      prefix: 'fix'
+      prefix_development: 'fix'
+      include_scope: true
+  - package_manager: 'javascript'
+    directory: '/packages/graphql-playground-middleware-lambda'
+    update_schedule: 'live'
+    allowed_updates:
+      - match:
+          update_type: 'security'
+    commit_message:
+      prefix: 'fix'
+      prefix_development: 'fix'
+      include_scope: true


### PR DESCRIPTION
because yarn workspaces was disabled at some point, dependabot is only monitoring the root yarn.lock. danger!
if you enable workspaces and update the underlying versions, and do yarn audit, you'll see more than dependabot reports (which is just the root it seems?)
github shows all the vulnerabilities in all lockfiles very prominently, however
this also adds conventional commits support so we don't have to rename the PRs for them to pass the CI in place