### PR TITLE
fix: workaround for bug in SettingsEditor

### DIFF
--- a/packages/graphql-playground-react/src/components/SettingsEditor.tsx
+++ b/packages/graphql-playground-react/src/components/SettingsEditor.tsx
@@ -98,7 +98,7 @@ class SettingsEditorHOC extends React.Component<
     this.props.editSettings()
   }
   handleSave = () => {
-    this.props.onSave(this.state.value)
+    this.props.onChange(this.state.value)
     this.props.saveSettings()
   }
 }


### PR DESCRIPTION
Fixes #1197.

[I broke this](https://github.com/prisma-labs/graphql-playground/pull/1191/files#diff-42484cc8d8c06e5994466038a84cd221R109) while updating TypeScript a few days back. 

There might be a better fix but for now this gets the job done.		