### PR TITLE
fix: schemaGetter props handling

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground.tsx
+++ b/packages/graphql-playground-react/src/components/Playground.tsx
@@ -252,7 +252,7 @@ export class Playground extends React.PureComponent<Props & ReduxProps, State> {
   }
 
   async schemaGetter(propsInput?: Props & ReduxProps) {
-    const props = this.props || propsInput
+    const props = propsInput || this.props
     const endpoint = props.sessionEndpoint || props.endpoint
     const currentSchema = this.state.schema
     try {
@@ -267,7 +267,7 @@ export class Playground extends React.PureComponent<Props & ReduxProps, State> {
         credentials: props.settings['request.credentials'],
         useTracingHeader:
           !this.initialSchemaFetch &&
-          this.props.settings['tracing.tracingSupported'],
+          props.settings['tracing.tracingSupported'],
       }
       const schema = await schemaFetcher.fetch(data)
       schemaFetcher.subscribe(data, newSchema => {


### PR DESCRIPTION
refs #1112.

Changes proposed in this pull request:
- use `props.settings['tracing.tracingSupported']` instead of `this.props.settings['tracing.tracingSupported']` same as `request.credentials`

- use `propsInput` as first instead of `this.props`. `this.props` is always non-null. maybe the opposite of the intention. `settings` doesn't exists in `this.props` at first.

@acao please take a look. I look forward to the release of #1112 🌹 