### PR TITLE
graphql-playground -> graphql-playground-react

### DIFF
--- a/packages/graphql-playground-react/README.md
+++ b/packages/graphql-playground-react/README.md
@@ -57,7 +57,7 @@ All interfaces, the React component `<Playground />` and all middlewares expose 
 #### Install
 
 ```sh
-yarn add graphql-playground
+yarn add graphql-playground-react
 ```
 
 #### Use
@@ -166,7 +166,7 @@ functions:
         cors: true
 ```
 
-## Development [![npm version](https://badge.fury.io/js/graphql-playground.svg)](https://badge.fury.io/js/graphql-playground)
+## Development [![npm version](https://badge.fury.io/js/graphql-playground-react.svg)](https://badge.fury.io/js/graphql-playground-react)
 
 This is a mono-repo setup containing packages for the `graphql-playground` and `graphql-playground-electron`.
 


### PR DESCRIPTION
It still refers to the old package