### PR TITLE
Extend graphql-playground-html options type

### DIFF
--- a/packages/graphql-playground-middleware-lambda/src/index.ts
+++ b/packages/graphql-playground-middleware-lambda/src/index.ts
@@ -1,10 +1,10 @@
 import * as lambda from 'aws-lambda'
 import {
-  MiddlewareOptions,
+  RenderPageOptions,
   renderPlaygroundPage,
 } from 'graphql-playground-html'
 
-export default function lambdaPlayground(options: MiddlewareOptions) {
+export default function lambdaPlayground(options: RenderPageOptions) {
   return async (
     _event,
     _lambdaContext: lambda.Context,


### PR DESCRIPTION
This change is required to be able to provide params like `cdnUrl`

This allows a fix to #1070