### PR TITLE
fix: don't gh release on lerna publish

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -16,8 +16,7 @@
         "**/examples"
       ],
       "message": "chore(release): publish",
-      "conventionalCommits": true,
-      "createRelease": "github"
+      "conventionalCommits": true
     }
   }
 }


### PR DESCRIPTION
because users expect an electron build for this, which we can't produce yet.