### PR TITLE
chore: cleanup xss example

### DIFF
--- a/packages/graphql-playground-html/examples/xss-attack/package.json
+++ b/packages/graphql-playground-html/examples/xss-attack/package.json
@@ -10,7 +10,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "apollo-server-express": "^2.11.0",
     "express": "^4.17.1",
     "graphql": "^15.0.0",
     "graphql-playground-html": "1.6.20",


### PR DESCRIPTION
remove express middleware from the example

Fixes #.

Changes proposed in this pull request:

- 

- 

- 
