### PR TITLE
fix: Koa middleware interface

### DIFF
--- a/packages/graphql-playground-middleware-koa/src/index.ts
+++ b/packages/graphql-playground-middleware-koa/src/index.ts
@@ -1,14 +1,15 @@
-import { Context } from 'koa'
+import { Context, Next } from 'koa'
 import {
   MiddlewareOptions,
   renderPlaygroundPage,
 } from 'graphql-playground-html'
 
+export declare type KoaPlaygroundMiddlewareOptions = MiddlewareOptions
+
 /* tslint:disable-next-line */
+export type KoaPlaygroundMiddleware = (ctx: Context, next: Next) => Promise<void>
 
-export type KoaPlaygroundMiddleware = (ctx: Context, next: () => void) => void
-
-export type Register = (options: MiddlewareOptions) => KoaPlaygroundMiddleware
+export type Register = (options: KoaPlaygroundMiddlewareOptions) => KoaPlaygroundMiddleware
 
 const koa: Register = options => {
   return async function voyager(ctx, next) {


### PR DESCRIPTION
Added the KoaPlaygroundMiddlewareOptions alias so that packages that want to pass around or preset the options don't have to fight the `eslint(import/no-extraneous-dependencies)` warning.

Fixed the signature of KoaPlaygroundMiddleware to actually match the usage: Koa expects this signature and the previous way was making things mighty hard to use, plus any function that is async is supposed to return a Promise anyway.

I think the tslint hint could be dropped now, but I'm creating this commit from GitHub's interface no I'm not sure. Also I think both KoaPlaygroundMiddleware and Register types could be dropped and the type declarations inlined on the actual lambdas, but I don't know if the extant pattern had a good reason or was just C&P from something else.
