### PR TITLE
fix: 'addLineBreaks' regex in 'createSDL' to avoid line-breaking comment lines

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/util/createSDL.ts
+++ b/packages/graphql-playground-react/src/components/Playground/util/createSDL.ts
@@ -65,9 +65,9 @@ function getTypeInstance(type) {
 function addLineBreaks(sdl: string, commentsDisabled: boolean = true) {
   const noNewLines = sdl.replace(/^\s*$(?:\r\n?|\n)/gm, '')
   // Line Break all Brackets
-  const breakBrackets = noNewLines.replace(/[}]/gm, '$&\r\n')
+  const breakBrackets = noNewLines.replace(/^[}]/gm, '$&\r\n')
   // Line Break all Scalars
-  const withLineBreaks = breakBrackets.replace(/(?:scalar )\w+/g, '$&\r\n')
+  const withLineBreaks = breakBrackets.replace(/^(?:scalar )\w+/gm, '$&\r\n')
 
   if (commentsDisabled) {
     return withLineBreaks


### PR DESCRIPTION
I have been using Playground for a while now with a GraphQL API developed in ASP.NET Core, using the open source library graphql-dotnet.

Everytime I download the SDL schema from Playground, there are several comment lines with line breaks in the middle, which makes the exported file invalid until I manually delete all unwanted line breaks.

After investigation, I found out that the library graphql-dotnet brings comments for scalar types containing the word "scalar" (like [this one](https://github.com/graphql-dotnet/graphql-dotnet/blob/master/src/GraphQL/Types/Scalars/DateGraphType.cs)) or even with closing braces in it (for example the [connection type](https://github.com/graphql-dotnet/graphql-dotnet/blob/master/src/GraphQL/Types/Relay/ConnectionType.cs)).
So, those comment lines are matched by the regex in function `addLineBreaks` which then adds unwanted line breaks, resulting in the following invalid schema file (cut for clarity):

![image](https://user-images.githubusercontent.com/12293953/85520188-de0ff900-b602-11ea-91a4-9b9717e32358.png)
![image](https://user-images.githubusercontent.com/12293953/85520315-0566c600-b603-11ea-8e44-572c6f538f50.png)

Changes proposed in this pull request:
- Change `breakBrackets` regex to match opening braces only on beginning of lines (to add a line break after a type)
- Change `withLineBreaks` regex to match the word 'scalar' only on beginning of lines and make it multiline

I hope my explanations are clear enough, and am looking forward to be able to export a valid SDL schema directly!
Thank you for your great work on this essential tool to develop GraphQL APIs!
