### PR TITLE
fix(graphql-playground-html): inside render-playground-page.ts removed  '/' from packageName and version

### DIFF
--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -89,7 +89,7 @@ const loading = getLoadingMarkup()
 const CONFIG_ID = 'playground-config';
 
 const getCdnMarkup = ({ version, cdnUrl = '//cdn.jsdelivr.net/npm', faviconUrl }) => {
-  const buildCDNUrl = (packageName: string, suffix: string) => filter(`${cdnUrl}/${packageName}/${version ? `@${version}/` : ''}${suffix}` || '')
+  const buildCDNUrl = (packageName: string, suffix: string) => filter(`${cdnUrl}/${packageName}${version ? `@${version}/` : ''}${suffix}` || '')
   return `
     <link 
       rel="stylesheet" 


### PR DESCRIPTION
# [Issue](https://github.com/prisma-labs/graphql-playground/issues/1254)

# Description

Removed incorrect dash `/` between `packageName` and `version` tag

## Type of change

-   [x] Non Breaking change




## Notes

```ts
const buildCDNUrl = (packageName: string, suffix: string) => filter(`${cdnUrl}/${packageName}/${version ? `@${version}/` : ''}${suffix}` || '')
```


When i am using the last version `patch` of `graphql-playground-html` i get response from the browser saying 

https://cdn.jsdelivr.net/npm/graphql-playground-react/@1.7.1/build/static/css/index.css
```
Couldn't find the requested file /@1.7.1/build/static/css/index.css in graphql-playground-react.
```

Also the same situation is for `js` bundle

https://cdn.jsdelivr.net/npm/graphql-playground-react/@1.7.1/build/static/js/middleware.js
```
Couldn't find the requested file /@1.7.1/build/static/js/middleware.js in graphql-playground-react.
```

What i have found out is that `buildCDNUrl` function has one `slash` more at the url so instead of 

```ts
filter(`${cdnUrl}/${packageName}/${version ? `@${version}/` : ''}${suffix}` || '')
```

We should have

```ts
filter(`${cdnUrl}/${packageName}${version ? `@${version}/` : ''}${suffix}` || '')
```

Maybe it is hard to notice but between ${packageName} and ${version...} we have `/` which is not correct `url`

Correct URL:

```
https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.1/build/static/css/index.css
```

Incorrect URL:

```
https://cdn.jsdelivr.net/npm/graphql-playground-react/@1.7.1/build/static/css/index.css
```