### PR TITLE
fix(examples): fix examples of reflected XSS attack

### DIFF
--- a/packages/graphql-playground-html/examples/xss-attack/README.md
+++ b/packages/graphql-playground-html/examples/xss-attack/README.md
@@ -50,6 +50,8 @@ http://localhost:4000/example-3?id=%3C/script%3E%3Cscript%3Ealert('I%20%3C3%20Gr
 
 this one uses static values, so it's safe without any workarounds! (try removing the ?darkMode parameter)
 
+http://localhost:4000/example-4?darkMode=%3C/script%3E%3Cscript%3Ealert('I%20%3C3%20GraphQL.%20Hack%20the%20Planet!!')%3C/script%3E%3Cscript%3E
+
 [XSS Safe using static configuration strings]("http://localhost:4000/example-3?darkMode")
 
 ## More Details

--- a/packages/graphql-playground-html/examples/xss-attack/index.js
+++ b/packages/graphql-playground-html/examples/xss-attack/index.js
@@ -80,7 +80,7 @@ app.get('/example-3', (req, res, next) => {
 
 // Example 4: Safe
 
-app.get('/example-3', (req, res, next) => {
+app.get('/example-4', (req, res, next) => {
   res.write(
     renderPlaygroundPage({
       endpoint: `/graphql`,

--- a/packages/graphql-playground-html/examples/xss-attack/package.json
+++ b/packages/graphql-playground-html/examples/xss-attack/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "apollo-server-express": "^2.16.0",
     "express": "^4.17.1",
     "graphql": "^15.0.0",
     "graphql-playground-html": "1.6.20",


### PR DESCRIPTION
Changes proposed in this pull request:

- fix: missing apollo-server-express which is necessary

- fix: wrong endpoint

- docs: add URI for example 4 (@acao I think that is what you intended to do but you've forgot to do that, is that right? :))
