### PR TITLE
Fix error with Copy CURL

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/TopBar/TopBar.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/TopBar/TopBar.tsx
@@ -22,6 +22,7 @@ import {
 import { share } from '../../../state/sharing/actions'
 import { openHistory } from '../../../state/general/actions'
 import { getSettings } from '../../../state/workspace/reducers'
+import { Session } from '../../../state/sessions/reducers'
 import { ISettings } from '../../../types'
 
 export interface Props {
@@ -30,6 +31,7 @@ export interface Props {
   fixedEndpoint?: boolean
   isPollingSchema: boolean
   endpointUnreachable: boolean
+  session: Session
 
   editEndpoint: (value: string) => void
   prettifyQuery: () => void
@@ -111,8 +113,7 @@ class TopBar extends React.Component<Props, {}> {
     this.props.openHistory()
   }
   getCurl = () => {
-    // no need to rerender the whole time. only on-demand the store is fetched
-    const session = getSelectedSession(this.context.store.getState())
+    const session = this.props.session
     let variables
     try {
       variables = JSON.parse(session.variables)
@@ -157,6 +158,7 @@ const mapStateToProps = createStructuredSelector({
   isPollingSchema: getIsPollingSchema,
   endpointUnreachable: getEndpointUnreachable,
   settings: getSettings,
+  session: getSelectedSession,
 })
 
 export default connect(


### PR DESCRIPTION
Fixes #1219.

This fixes the error `TypeError: t.context.store is undefined ` which currently occurs whenever you click on "Copy CURL".