### PR TITLE
refactor: remove unnecessary envrc file

### DIFF
--- a/packages/graphql-playground-html/examples/xss-attack/.envrc
+++ b/packages/graphql-playground-html/examples/xss-attack/.envrc
@@ -1,1 +1,0 @@
-export PORT=4000


### PR DESCRIPTION
It seems that .envrc has been used at some point during local development before pushing to merge (#1231), but seems that it  isn't being used any more since PORT is being declared in index.js. 
